### PR TITLE
Update test_airflow_success.ipynb

### DIFF
--- a/include/notebooks/test_airflow_success.ipynb
+++ b/include/notebooks/test_airflow_success.ipynb
@@ -6,7 +6,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install scikit-learn"
+    "!pip install scikit-learn==1.1.1"
    ]
   },
   {


### PR DESCRIPTION
Newer version cause issue while loading data. 
This is fixing that issue.
Tried in 
RHOCP 4.13.9 
RHODS 1.31.0 
